### PR TITLE
Fixed add and remove conntrack ignore rules to iptables raw table

### DIFF
--- a/scripts/vyatta-conntrack-ignore.pl
+++ b/scripts/vyatta-conntrack-ignore.pl
@@ -35,7 +35,7 @@ openlog("vyatta-conntrack", "pid", "local0");
 
 sub remove_ignore_policy {
     my ($rule_string) = @_;
-    my $iptables_cmd1 = "iptables -D VYATTA_CT_IGNORE -t raw $rule_string -j NOTRACK";
+    my $iptables_cmd1 = "iptables -D VYATTA_CT_IGNORE -t raw $rule_string -j CT --notrack";
     my $iptables_cmd2 = "iptables -D VYATTA_CT_IGNORE -t raw $rule_string -j RETURN";
     run_cmd($iptables_cmd2);
     if ($? >> 8) {
@@ -51,7 +51,7 @@ sub remove_ignore_policy {
 sub apply_ignore_policy {
    my ($rule_string, $rule, $num_rules) = @_;
    # insert at num_rules + 1 as there are so many rules already. 
-   my $iptables_cmd1 = "iptables -I VYATTA_CT_IGNORE $num_rules -t raw $rule_string -j NOTRACK";
+   my $iptables_cmd1 = "iptables -I VYATTA_CT_IGNORE $num_rules -t raw $rule_string -j CT --notrack";
    $num_rules +=1;
    my $iptables_cmd2 = "iptables -I VYATTA_CT_IGNORE $num_rules -t raw $rule_string -j RETURN";
    run_cmd($iptables_cmd1);


### PR DESCRIPTION
Fixed error when deleting conntrack ignore rules in last versions vyos based on debian 10 and used iptables-nft

# delete system conntrack ignore rule 50
[edit]
# commit
[ system conntrack ignore ]
iptables: Bad rule (does a matching rule exist in that chain?).
Conntrack ignore  error: failed to run iptables -D VYATTA_CT_IGNORE -t raw  -m comment --comment "ignore-50"  -i eth2     -j NOTRACK