### PR TITLE
conntrack: T4165: Fix comment for correct delete custom rules

### DIFF
--- a/lib/Vyatta/Conntrack/RuleCT.pm
+++ b/lib/Vyatta/Conntrack/RuleCT.pm
@@ -63,7 +63,6 @@ sub rule {
   my $tcp_and_udp = 0;
   # set CLI rule num as comment
   my @level_nodes = split (' ', $self->{_comment});
-  $rule .= "-m comment --comment \"$level_nodes[2]-$level_nodes[5]\" ";
   ($srcrule, $err_str) = $src->rule();
   if (defined($err_str)) {
         Vyatta::Config::outputError(["Conntrack"], "Conntrack config error: $err_str");
@@ -92,6 +91,8 @@ sub rule {
   } else {
     $rule .= " $srcrule $dstrule ";
    }
+
+  $rule .= "-m comment --comment \"$level_nodes[2]-$level_nodes[5]\" ";
 
   return $rule;
 }


### PR DESCRIPTION
For correct deleting rules iptables "comment" should be in the end of the line
Incorrect sequence:
```-D VYATTA_CT_TIMEOUT -t raw -m comment --comment "timeout-10" -p tcp```
Correct:
```-D VYATTA_CT_TIMEOUT -t raw -p tcp -m comment --comment "timeout-10"```

https://phabricator.vyos.net/T4165

How to test:
Add custom conntrack rules and delete them, after deleting all iptables generated rules should be deleted without errors.
```
set system conntrack timeout custom rule 10 destination address '203.0.113.74'
set system conntrack timeout custom rule 10 destination port '80'
set system conntrack timeout custom rule 10 protocol tcp established '300'
set system conntrack timeout custom rule 10 source address '192.0.2.168'
commit
```
Iptables:
```
vyos@r4# sudo iptables -S -t raw | grep -i timeou
-N VYATTA_CT_TIMEOUT
-A PREROUTING -j VYATTA_CT_TIMEOUT
-A OUTPUT -j VYATTA_CT_TIMEOUT
-A VYATTA_CT_TIMEOUT -s 192.0.2.168/32 -d 203.0.113.74/32 -p tcp -m tcp --dport 80 -m comment --comment timeout-10 -j CT --timeout poli
-A VYATTA_CT_TIMEOUT -s 192.0.2.168/32 -d 203.0.113.74/32 -p tcp -m tcp --dport 80 -m comment --comment timeout-10 -j RETURN
-A VYATTA_CT_TIMEOUT -j RETURN
[edit]
vyos@r4# 
```
Delete rules:
```
vyos@r4# delete system conntrack 
[edit]
vyos@r4# commit
[edit]
vyos@r4# sudo iptables -S -t raw | grep -i timeou
-N VYATTA_CT_TIMEOUT
-A PREROUTING -j VYATTA_CT_TIMEOUT
-A OUTPUT -j VYATTA_CT_TIMEOUT
-A VYATTA_CT_TIMEOUT -j RETURN
[edit]
vyos@r4# 
```