### PR TITLE
conntrack: T4993: Fix comment for correct delete ignore rules

### DIFF
--- a/lib/Vyatta/Conntrack/RuleIgnore.pm
+++ b/lib/Vyatta/Conntrack/RuleIgnore.pm
@@ -26,8 +26,7 @@ sub rule {
   my $tcp_and_udp = 0;
   # set CLI rule num as comment
   my @level_nodes = split (' ', $self->{_comment});
-  $rule .= " -m comment --comment \"$level_nodes[2]-$level_nodes[4]\" ";
-  
+
   if (defined($self->{_interface})) {
     $rule .= " -i $self->{_interface} ";
   }
@@ -58,6 +57,7 @@ sub rule {
   } else {
     $rule .= " $srcrule $dstrule ";
    }
+  $rule .= " -m comment --comment \"$level_nodes[2]-$level_nodes[4]\" ";
   return $rule;
 }
 


### PR DESCRIPTION
For correct deleting rules iptables "comment" should be in the end of the line
Incorrect:
-D VYATTA_CT_IGNORE -t raw -m comment --comment "ignore-10" -p udp 
Correct:
-D VYATTA_CT_IGNORE -t raw -p udp -m comment --comment "ignore-10"

https://vyos.dev/T4993

How to test:
Add custom conntrack rules and delete them, after deleting all iptables generated rules should be deleted without errors.

```
set system conntrack ignore rule 30 protocol 'udp'
set system conntrack ignore rule 30 source address '10.0.1.2'
set system conntrack ignore rule 30 source port '51822'
commit
```
Iptables:

```
vyos@vyos# sudo iptables -S -t raw | grep -i timeou
-N VYATTA_CT_IGNORE
-A PREROUTING -j VYATTA_CT_IGNORE
-A OUTPUT -j VYATTA_CT_IGNORE
-A VYATTA_CT_IGNORE -s 10.0.1.2/32 -p udp -m udp --sport 51822 -m comment --comment ignore-30 -j CT --notrack
-A VYATTA_CT_IGNORE -s 10.0.1.2/32 -p udp -m udp --sport 51822 -m comment --comment ignore-30 -j RETURN
-A VYATTA_CT_IGNORE -j RETURN
```

Delete rules:

```
vyos@vyos# delete system conntrack 
[edit]
vyos@vyos# commit
[edit]
vyos@vyost# sudo iptables -S -t raw | grep IGNORE
-N VYATTA_CT_IGNORE
-A PREROUTING -j VYATTA_CT_IGNORE
-A OUTPUT -j VYATTA_CT_IGNORE
-A VYATTA_CT_IGNORE -j RETURN

```